### PR TITLE
Update rails.dev -> rails.local

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Run a local rails app with nothing but Nanobox.
 2. Change into the directory
         `cd nanobox-rails`
 3. Add a local DNS record
-        `nanobox dns add local rails.dev`
+        `nanobox dns add local rails.local`
 4. Create the database
         `nanobox run rake db:create`
 5. Run the app


### PR DESCRIPTION
running `nanobox dns add local rails.dev` results in: 

```
Error   : Google has been locking down use of the .dev TLD, and your app may not be accessible with this domain.
Try using rails.local instead.
Context :
```